### PR TITLE
レシピサイトから食材の要素をスクレイピングして、フォームに入力する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,8 @@ gem 'pry-rails'
 
 gem 'line-bot-api'
 gem 'nokogiri'
+
+# スクレイピング用
+gem 'mechanize'
+gem 'selenium-webdriver'
+gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
       ssrf_filter (~> 1.0, < 1.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     crass (1.0.6)
     cssbundling-rails (1.3.3)
       railties (>= 6.0.0)
@@ -103,6 +104,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    domain_name (0.6.20231109)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -118,6 +120,8 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -142,6 +146,17 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    mechanize (2.9.1)
+      addressable (~> 2.8)
+      domain_name (~> 0.5, >= 0.5.20190701)
+      http-cookie (~> 1.0, >= 1.0.3)
+      mime-types (~> 3.0)
+      net-http-digest_auth (~> 1.4, >= 1.4.1)
+      net-http-persistent (>= 2.5.2, < 5.0.dev)
+      nokogiri (~> 1.11, >= 1.11.2)
+      rubyntlm (~> 0.6, >= 0.6.3)
+      webrick (~> 1.7)
+      webrobots (~> 0.1.2)
     method_source (1.0.0)
     mime-types (3.5.1)
       mime-types-data (~> 3.2015)
@@ -151,6 +166,9 @@ GEM
     minitest (5.20.0)
     msgpack (1.7.2)
     multi_xml (0.6.0)
+    net-http-digest_auth (1.4.1)
+    net-http-persistent (4.0.2)
+      connection_pool (~> 2.2)
     net-imap (0.4.5)
       date
       net-protocol
@@ -243,6 +261,7 @@ GEM
       railties (>= 5.2)
     rexml (3.2.6)
     ruby2_keywords (0.0.5)
+    rubyntlm (0.6.3)
     rubyzip (2.3.2)
     selenium-webdriver (4.15.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -278,6 +297,8 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webrick (1.8.1)
+    webrobots (0.1.2)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -301,6 +322,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   line-bot-api
+  mechanize
   mini_magick
   nokogiri
   omniauth-line

--- a/app/controllers/repertoires_controller.rb
+++ b/app/controllers/repertoires_controller.rb
@@ -14,7 +14,7 @@ class RepertoiresController < ApplicationController
     if @repertoire.save_with_ingredients(ingredient_names: ingredient_names)
       redirect_to repertoires_path(@repertoire), success: 'レパートリーを作成しました'
     else
-      flash.now['danger'] = 'レパートリーを作成できませんでした'
+      flash.now[:alert] = 'レパートリーを作成できませんでした'
       render :new, status: :unprocessable_entity
     end
   end
@@ -31,7 +31,7 @@ class RepertoiresController < ApplicationController
     if @repertoire.save_with_ingredients(ingredient_names: params.dig(:repertoire, :ingredient_names).split(',').uniq)
       redirect_to repertoire_path(@repertoire), success: 'レパートリーを更新しました'
     else
-      flash.now[:danger] = 'レパートリーを更新できませんでした'
+      flash.now[:alert] = 'レパートリーを更新できませんでした'
       render :edit
     end
   end

--- a/app/controllers/repertoires_controller.rb
+++ b/app/controllers/repertoires_controller.rb
@@ -9,14 +9,20 @@ class RepertoiresController < ApplicationController
   end
 
   def create
-    @repertoire = current_user.repertoires.new(repertoire_params)
-    if @repertoire.save_with_ingredients(ingredient_names: params.dig(:repertoire, :ingredient_names).split(',').uniq)
+    @repertoire = current_user.repertoires.create(repertoire_params)
+    ingredient_names = params.dig(:repertoire, :ingredient_names).to_s.split(',').map(&:strip).uniq
+    
+    binding.pry
+    
+  
+    if @repertoire.save_with_ingredients(ingredient_names: ingredient_names)
       redirect_to repertoires_path(@repertoire), success: 'レパートリーを作成しました'
     else
       flash.now['danger'] = 'レパートリーを作成できませんでした'
       render :new, status: :unprocessable_entity
     end
   end
+  
 
   def show
     @repertoire = Repertoire.find(params[:id])
@@ -39,13 +45,50 @@ class RepertoiresController < ApplicationController
     redirect_to repertoires_path, success: '削除しました'
   end
 
+  def scrape
+    @url = params.dig(:repertoire, :recipe_url)
+    
+    binding.pry
+    
+  
+    begin
+      # スクレイピングして食材名のリストを取得
+      @ingredient_names = scrape_page(@url)
+  
+      # スクレイピングした食材名のリストをセッションに保存する
+      session[:scraped_ingredients] = @ingredient_names
+  
+      # スクレイピング成功の通知
+      redirect_to new_repertoire_path, notice: 'スクレイピングが完了しました。'
+    rescue => e
+      flash.now[:alert] = "スクレイピングに失敗しました: #{e.message}"
+      render :index
+    end
+  end
+
   private
 
   def repertoire_params
-    params.require(:repertoire).permit(:name, :recipe_url, :repertoire_image, :repertoire_image_cache)
+    params.require(:repertoire).permit(:name, :recipe_url, :repertoire_image, :repertoire_image_cache, ingredient_ids: [])
   end
 
   def set_repertoire
     @repertoire = current_user.repertoires.find(params[:id])
+  end
+
+  # スクレイピングを行うメソッド
+  def scrape_page(url)
+    agent = Mechanize.new
+    page = agent.get(url)
+    doc = Nokogiri::HTML(page.body)
+  
+    ingredients_container = doc.at('#ingredients_list')
+    ingredient_names = ingredients_container.css('.ingredient_name .name').map(&:text)
+    
+    binding.pry
+    
+
+    ingredient_names.uniq
+
   end
 end

--- a/app/controllers/repertoires_controller.rb
+++ b/app/controllers/repertoires_controller.rb
@@ -11,10 +11,6 @@ class RepertoiresController < ApplicationController
   def create
     @repertoire = current_user.repertoires.create(repertoire_params)
     ingredient_names = params.dig(:repertoire, :ingredient_names).to_s.split(',').map(&:strip).uniq
-    
-    binding.pry
-    
-  
     if @repertoire.save_with_ingredients(ingredient_names: ingredient_names)
       redirect_to repertoires_path(@repertoire), success: 'レパートリーを作成しました'
     else
@@ -46,20 +42,18 @@ class RepertoiresController < ApplicationController
   end
 
   def scrape
-    @url = params.dig(:repertoire, :recipe_url)
-    
-    binding.pry
-    
-  
+    @url = params[:recipe_url]
     begin
       # スクレイピングして食材名のリストを取得
       @ingredient_names = scrape_page(@url)
   
       # スクレイピングした食材名のリストをセッションに保存する
       session[:scraped_ingredients] = @ingredient_names
+
+      render json: { ingredients: @ingredient_names }
   
       # スクレイピング成功の通知
-      redirect_to new_repertoire_path, notice: 'スクレイピングが完了しました。'
+
     rescue => e
       flash.now[:alert] = "スクレイピングに失敗しました: #{e.message}"
       render :index
@@ -84,9 +78,6 @@ class RepertoiresController < ApplicationController
   
     ingredients_container = doc.at('#ingredients_list')
     ingredient_names = ingredients_container.css('.ingredient_name .name').map(&:text)
-    
-    binding.pry
-    
 
     ingredient_names.uniq
 

--- a/app/controllers/scrapers_controller.rb
+++ b/app/controllers/scrapers_controller.rb
@@ -1,3 +1,61 @@
+require 'mechanize'
+require 'selenium-webdriver'
+require 'nokogiri'
+
 class ScrapersController < ApplicationController
-  def index;end
+# 新しいRepertoireを作成し、それぞれのIngredientを作成または取得するメソッド
+def save_repertoire_ingredients(name, unique_ingredient_names)
+  # 新しいRepertoireを作成
+  repertoire = Repertoire.create(name: name)
+
+  # それぞれのIngredientを作成または取得
+  unique_ingredient_names.each do |ingredient_name|
+    ingredient = Ingredient.find_or_create_by(name: ingredient_name)
+
+    # RepertoireとIngredientを関連付ける
+    repertoire.ingredients << ingredient
+  end
+end
+
+# ページをスクレイピングするメソッド
+def scrape_page(url)
+  # Mechanize::WebDriver インスタンスを作成
+  agent = Mechanize.new
+
+  # 指定された URL にアクセス
+  page = agent.get(url)
+
+  # ページの HTML を Nokogiri で解析
+  doc = Nokogiri::HTML(page.body)
+
+  # 材料という題名の要素を取得
+  # "材料" というテキストを持つ要素を探す
+  # 材料という題名の要素を取得
+  ingredients_container = doc.at('#ingredients_list')
+
+  # ingredient_nameの要素を取得
+  ingredient_names = ingredients_container.css('.ingredient_name .name').map(&:text)
+
+  # 重複した要素を省く
+  unique_ingredient_names = ingredient_names.uniq
+
+  # 結果を出力
+  puts '材料:'
+  puts unique_ingredient_names
+
+  # save_repertoire_ingredients メソッドを呼び出す
+  save_repertoire_ingredients(params[:name], unique_ingredient_names)
+end
+
+# GET /scraper/index
+def index; end
+
+# POST /scraper/scrape
+def scrape
+  @url = params[:url]
+  # ページをスクレイピング
+  scrape_page(@url)
+
+  # 他の処理（例: レンダリング、リダイレクトなど）も行う場合はここに追加
+end
 end

--- a/app/controllers/scrapers_controller.rb
+++ b/app/controllers/scrapers_controller.rb
@@ -3,59 +3,68 @@ require 'selenium-webdriver'
 require 'nokogiri'
 
 class ScrapersController < ApplicationController
-# 新しいRepertoireを作成し、それぞれのIngredientを作成または取得するメソッド
-def save_repertoire_ingredients(name, unique_ingredient_names)
-  # 新しいRepertoireを作成
-  repertoire = Repertoire.create(name: name)
+  # 新しいRepertoireを作成し、それぞれのIngredientを作成または取得するメソッド∂
+  def save_repertoire_ingredients(current_user, name, unique_ingredient_names)
+    # 新しいRepertoireを作成
+    repertoire = current_user.repertoires.create(name: name)
 
-  # それぞれのIngredientを作成または取得
-  unique_ingredient_names.each do |ingredient_name|
-    ingredient = Ingredient.find_or_create_by(name: ingredient_name)
+    # それぞれのIngredientを作成または取得
+    unique_ingredient_names.each do |ingredient_name|
+      ingredient = Ingredient.find_or_create_by(name: ingredient_name)
 
-    # RepertoireとIngredientを関連付ける
-    repertoire.ingredients << ingredient
+      # RepertoireとIngredientを関連付ける
+
+      repertoire.ingredients << ingredient
+    end
   end
-end
 
-# ページをスクレイピングするメソッド
-def scrape_page(url)
-  # Mechanize::WebDriver インスタンスを作成
-  agent = Mechanize.new
+  # ページをスクレイピングするメソッド
+  def scrape_page(url)
+    # Mechanize::WebDriver インスタンスを作成
+    agent = Mechanize.new
 
-  # 指定された URL にアクセス
-  page = agent.get(url)
+    # 指定された URL にアクセス
+    page = agent.get(url)
 
-  # ページの HTML を Nokogiri で解析
-  doc = Nokogiri::HTML(page.body)
+    # ページの HTML を Nokogiri で解析
+    doc = Nokogiri::HTML(page.body)
 
-  # 材料という題名の要素を取得
-  # "材料" というテキストを持つ要素を探す
-  # 材料という題名の要素を取得
-  ingredients_container = doc.at('#ingredients_list')
+    # 材料という題名の要素を取得
+    # "材料" というテキストを持つ要素を探す
+    # 材料という題名の要素を取得
+    ingredients_container = doc.at('#ingredients_list')
 
-  # ingredient_nameの要素を取得
-  ingredient_names = ingredients_container.css('.ingredient_name .name').map(&:text)
+    # ingredient_nameの要素を取得
+    ingredient_names = ingredients_container.css('.ingredient_name .name').map(&:text)
 
-  # 重複した要素を省く
-  unique_ingredient_names = ingredient_names.uniq
+    # 重複した要素を省く
+    unique_ingredient_names = ingredient_names.uniq
 
-  # 結果を出力
-  puts '材料:'
-  puts unique_ingredient_names
+    # 結果を出力
+    puts '材料:'
+    puts unique_ingredient_names
 
-  # save_repertoire_ingredients メソッドを呼び出す
-  save_repertoire_ingredients(params[:name], unique_ingredient_names)
-end
+    # save_repertoire_ingredients メソッドを呼び出す
+    save_repertoire_ingredients(current_user, params[:name], unique_ingredient_names)
+  end
 
-# GET /scraper/index
-def index; end
+  # GET /scraper/index
+  def index; end
 
-# POST /scraper/scrape
-def scrape
-  @url = params[:url]
-  # ページをスクレイピング
-  scrape_page(@url)
+  # POST /scraper/scrape
+  def scrape
+    @url = params[:url]
 
-  # 他の処理（例: レンダリング、リダイレクトなど）も行う場合はここに追加
+    begin
+      # ページをスクレイピング
+      scrape_page(@url)
+
+      # スクレイピングが成功した場合、/repertoiresにリダイレクト
+      redirect_to repertoires_path, notice: 'スクレイピングが完了しました。'
+    rescue => e
+      # エラーが発生した場合、エラーメッセージを設定してフォーム画面を再表示
+      flash.now[:alert] = "スクレイピングに失敗しました: #{e.message}"
+      render :index
+    end
 end
 end

--- a/app/controllers/scrapers_controller.rb
+++ b/app/controllers/scrapers_controller.rb
@@ -1,0 +1,3 @@
+class ScrapersController < ApplicationController
+  def index;end
+end

--- a/app/controllers/scrapers_controller.rb
+++ b/app/controllers/scrapers_controller.rb
@@ -3,49 +3,17 @@ require 'selenium-webdriver'
 require 'nokogiri'
 
 class ScrapersController < ApplicationController
-  # 新しいRepertoireを作成し、それぞれのIngredientを作成または取得するメソッド∂
-  def save_repertoire_ingredients(current_user, name, unique_ingredient_names)
-    # 新しいRepertoireを作成
-    repertoire = current_user.repertoires.create(name: name)
-
-    # それぞれのIngredientを作成または取得
-    unique_ingredient_names.each do |ingredient_name|
-      ingredient = Ingredient.find_or_create_by(name: ingredient_name)
-
-      # RepertoireとIngredientを関連付ける
-
-      repertoire.ingredients << ingredient
-    end
-  end
-
   # ページをスクレイピングするメソッド
   def scrape_page(url)
-    # Mechanize::WebDriver インスタンスを作成
     agent = Mechanize.new
-
-    # 指定された URL にアクセス
     page = agent.get(url)
-
-    # ページの HTML を Nokogiri で解析
     doc = Nokogiri::HTML(page.body)
-
-    # 材料という題名の要素を取得
-    # "材料" というテキストを持つ要素を探す
-    # 材料という題名の要素を取得
+  
     ingredients_container = doc.at('#ingredients_list')
-
-    # ingredient_nameの要素を取得
     ingredient_names = ingredients_container.css('.ingredient_name .name').map(&:text)
 
-    # 重複した要素を省く
-    unique_ingredient_names = ingredient_names.uniq
+    ingredient_names.uniq
 
-    # 結果を出力
-    puts '材料:'
-    puts unique_ingredient_names
-
-    # save_repertoire_ingredients メソッドを呼び出す
-    save_repertoire_ingredients(current_user, params[:name], unique_ingredient_names)
   end
 
   # GET /scraper/index
@@ -53,18 +21,20 @@ class ScrapersController < ApplicationController
 
   # POST /scraper/scrape
   def scrape
-    @url = params[:url]
-
+    @url = params[:recipe_url]
+  
     begin
-      # ページをスクレイピング
-      scrape_page(@url)
-
-      # スクレイピングが成功した場合、/repertoiresにリダイレクト
-      redirect_to repertoires_path, notice: 'スクレイピングが完了しました。'
+      # スクレイピングして食材名のリストを取得
+      @ingredient_names = scrape_page(@url)
+  
+      # スクレイピングした食材名のリストをセッションに保存する
+      session[:scraped_ingredients] = @ingredient_names
+  
+      # スクレイピング成功の通知
+      redirect_to new_repertoire_path, notice: 'スクレイピングが完了しました。'
     rescue => e
-      # エラーが発生した場合、エラーメッセージを設定してフォーム画面を再表示
       flash.now[:alert] = "スクレイピングに失敗しました: #{e.message}"
       render :index
     end
-end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,16 @@
 module ApplicationHelper
+  def flash_class(type)
+    case type
+    when 'notice'
+      'text-blue-600 bg-blue-100'
+    when 'alert'
+      'text-red-600 bg-red-100'
+    when 'success'
+      'text-green-600 bg-green-100'
+    when 'warning'
+      'text-yellow-600 bg-yellow-100'
+    else
+      'text-gray-600 bg-gray-100'
+    end
+  end
 end

--- a/app/helpers/scrapers_helper.rb
+++ b/app/helpers/scrapers_helper.rb
@@ -1,0 +1,2 @@
+module ScrapersHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails";
 import "./controllers";
 import "./preview";
+import "./scrape";

--- a/app/javascript/scrape.js
+++ b/app/javascript/scrape.js
@@ -1,0 +1,30 @@
+document.addEventListener("turbo:load", function () {
+  document.getElementById("scrape-button").addEventListener("click", function (e) {
+    e.preventDefault();
+    var recipeUrl = document.getElementById("recipe_url").value;
+    
+    // CSRFトークンを取得
+    var token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+    // ingredients変数を定義
+    var ingredients = [];
+
+    fetch('/repertoires/scrape', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': token // CSRFトークンをヘッダーに追加
+      },
+      body: JSON.stringify({ recipe_url: recipeUrl })
+    })
+    .then(response => response.json())
+    .then(data => {
+      console.log(data.ingredients);
+      // スクレイピング結果をingredients変数に代入
+      var ingredients = data.ingredients;
+      // スクレイピング結果をフォームに反映
+      document.getElementById("repertoire_ingredient_names").value = ingredients.join(", ");
+    })
+    .catch(error => console.error('Error:', error)); // エラーハンドリングを追加
+  });
+});

--- a/app/javascript/scrape.js
+++ b/app/javascript/scrape.js
@@ -1,3 +1,4 @@
+console.log("hello!")
 document.addEventListener("turbo:load", function () {
   document.getElementById("scrape-button").addEventListener("click", function (e) {
     e.preventDefault();

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,9 +13,7 @@
   <body>
       <%= render 'shared/header' %>
       <%= render 'shared/flash_message' %>
-      <div class=" bg-body-dark py-6 sm:py-8 lg:py-12">
-        <%= yield %>
-      </div>
+      <%= yield %>
       <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,9 +11,11 @@
   </head>
 
   <body>
-    <%= render 'shared/header' %>
-    <%= render 'shared/flash_message' %>
-    <%= yield %>
-    <%= render 'shared/footer' %>
+      <%= render 'shared/header' %>
+      <%= render 'shared/flash_message' %>
+      <div class=" bg-body-dark py-6 sm:py-8 lg:py-12">
+        <%= yield %>
+      </div>
+      <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/repertoires/_form.html.erb
+++ b/app/views/repertoires/_form.html.erb
@@ -2,25 +2,14 @@
   <!-- Author: FormBold Team -->
   <!-- Learn More: https://formbold.com -->
   <div class="mx-auto w-full max-w-[550px]">
-    <%= form_with model: repertoire, url: repertoires_scrape_path, method: :post, local: true do |f| %>
+    <%= form_with url: scrape_repertoires_path, method: :post, local: true do |f| %>
       参考URL
       <%= f.text_field :recipe_url, placeholder: 'https://', class: 'w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md' %>
-      <%= f.submit 'スクレイピング開始', class: 'btn btn-primary mb-3' %>
+      <%= button_tag 'スクレイピング開始', id: 'scrape-button', class: 'btn btn-primary mb-3' %>
     <% end %>
+
     <%= form_with model: repertoire, local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
-      <div class="mb-5">
-        <%= f.label :recipe_url, class: 'mb-3 block text-base font-medium text-[#07074D]' do %>
-          参考URL
-        <% end %>
-        <%= f.text_field :recipe_url, placeholder: 'https://', class: 'w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md' %>
-      </div>
-      <%= button_tag 'スクレイピング開始', data: { turbo_frame: "scraping_result" }, class: 'btn btn-primary mb-3' %>
-      <!-- Turbo Frameの追加 -->
-      <%= turbo_frame_tag "scraping_result" do %>
-        <!-- スクレイピング結果がここに挿入される -->
-      <% end %>
-
       <div class="mb-5">
         <%= f.label :name, class: 'mb-3 block text-base font-medium text-[#07074D]' do %>
           料理名

--- a/app/views/repertoires/_form.html.erb
+++ b/app/views/repertoires/_form.html.erb
@@ -2,14 +2,16 @@
   <!-- Author: FormBold Team -->
   <!-- Learn More: https://formbold.com -->
   <div class="mx-auto w-full max-w-[550px]">
+  <!-- スクレイピングフォーム -->
     <%= form_with url: scrape_repertoires_path, method: :post, local: true do |f| %>
-      参考URL
-      <%= f.text_field :recipe_url, placeholder: 'https://', class: 'w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md' %>
-      <%= button_tag 'スクレイピング開始', id: 'scrape-button', class: 'btn btn-primary mb-3' %>
+      <div class="join flex mb-5">
+        <%= f.text_field :recipe_url, placeholder: 'https://', class: 'py-3 px-6 w-full input input-bordered join-item rounded-md border border-[#e0e0e0] bg-white text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md' %>
+        <%= button_tag '食材取得', id: 'scrape-button', class: "btn join-item text-white bg-yellow-400 border-0 focus:outline-none hover:bg-yellow-600 rounded text-md" %>
+      </div>
     <% end %>
-
+    <!-- レパートリー登録フォーム -->
     <%= form_with model: repertoire, local: true do |f| %>
-      <%= render 'shared/error_messages', object: f.object %>
+    <%= render 'shared/error_messages', object: f.object %>
       <div class="mb-5">
         <%= f.label :name, class: 'mb-3 block text-base font-medium text-[#07074D]' do %>
           料理名

--- a/app/views/repertoires/_form.html.erb
+++ b/app/views/repertoires/_form.html.erb
@@ -4,12 +4,12 @@
   <div class="mx-auto w-full max-w-[550px]">
     <!-- レパートリー登録フォーム -->
     <%= form_with model: repertoire, local: true do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
       <div class="mb-5">
         <%= f.label :name, class: 'mb-3 block text-base font-medium text-[#07074D]' do %>
           料理名<span class="required text-red-500 mx-1" aria-hidden="true">*</span>
         <% end %>
         <%= f.text_field :name, placeholder: '例: ハンバーグ', class: 'w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md' %>
-        <%= render 'shared/error_messages', object: f.object %>
       </div>
       <div class="mb-5">
         <%= f.label :recipe_url, class: 'mb-3 block text-base font-medium text-[#07074D]' do %>

--- a/app/views/repertoires/_form.html.erb
+++ b/app/views/repertoires/_form.html.erb
@@ -2,21 +2,23 @@
   <!-- Author: FormBold Team -->
   <!-- Learn More: https://formbold.com -->
   <div class="mx-auto w-full max-w-[550px]">
-  <!-- スクレイピングフォーム -->
-    <%= form_with url: scrape_repertoires_path, method: :post, local: true do |f| %>
-      <div class="join flex mb-5">
-        <%= f.text_field :recipe_url, placeholder: 'https://', class: 'py-3 px-6 w-full input input-bordered join-item rounded-md border border-[#e0e0e0] bg-white text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md' %>
-        <%= button_tag '食材取得', id: 'scrape-button', class: "btn join-item text-white bg-yellow-400 border-0 focus:outline-none hover:bg-yellow-600 rounded text-md" %>
-      </div>
-    <% end %>
     <!-- レパートリー登録フォーム -->
     <%= form_with model: repertoire, local: true do |f| %>
-    <%= render 'shared/error_messages', object: f.object %>
       <div class="mb-5">
         <%= f.label :name, class: 'mb-3 block text-base font-medium text-[#07074D]' do %>
-          料理名
+          料理名<span class="required text-red-500 mx-1" aria-hidden="true">*</span>
         <% end %>
         <%= f.text_field :name, placeholder: '例: ハンバーグ', class: 'w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md' %>
+        <%= render 'shared/error_messages', object: f.object %>
+      </div>
+      <div class="mb-5">
+        <%= f.label :recipe_url, class: 'mb-3 block text-base font-medium text-[#07074D]' do %>
+          参考にしたURL
+        <% end %>
+        <div class="join flex mb-5">
+          <%= f.text_field :recipe_url, id: 'recipe_url', placeholder: 'https://', class: 'py-3 px-6 w-full input input-bordered join-item rounded-md border border-[#e0e0e0] bg-white text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md' %>
+          <%= button_tag '食材取得', id: 'scrape-button', class: "btn join-item text-white bg-yellow-400 border-0 focus:outline-none hover:bg-yellow-600 rounded text-md" %>
+        </div>
       </div>
       <div class="mb-5">
         <%= f.label :ingredient_names, class: 'mb-3 block text-base font-medium text-[#07074D]' do %>

--- a/app/views/repertoires/_form.html.erb
+++ b/app/views/repertoires/_form.html.erb
@@ -2,6 +2,11 @@
   <!-- Author: FormBold Team -->
   <!-- Learn More: https://formbold.com -->
   <div class="mx-auto w-full max-w-[550px]">
+    <%= form_with model: repertoire, url: repertoires_scrape_path, method: :post, local: true do |f| %>
+      参考URL
+      <%= f.text_field :recipe_url, placeholder: 'https://', class: 'w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md' %>
+      <%= f.submit 'スクレイピング開始', class: 'btn btn-primary mb-3' %>
+    <% end %>
     <%= form_with model: repertoire, local: true do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
       <div class="mb-5">
@@ -10,6 +15,12 @@
         <% end %>
         <%= f.text_field :recipe_url, placeholder: 'https://', class: 'w-full rounded-md border border-[#e0e0e0] bg-white py-3 px-6 text-base font-medium text-[#6B7280] outline-none focus:border-[#6A64F1] focus:shadow-md' %>
       </div>
+      <%= button_tag 'スクレイピング開始', data: { turbo_frame: "scraping_result" }, class: 'btn btn-primary mb-3' %>
+      <!-- Turbo Frameの追加 -->
+      <%= turbo_frame_tag "scraping_result" do %>
+        <!-- スクレイピング結果がここに挿入される -->
+      <% end %>
+
       <div class="mb-5">
         <%= f.label :name, class: 'mb-3 block text-base font-medium text-[#07074D]' do %>
           料理名

--- a/app/views/repertoires/_scraping_result.html.erb
+++ b/app/views/repertoires/_scraping_result.html.erb
@@ -1,1 +1,0 @@
-<h3>< %= @ingredient_names %></h3>

--- a/app/views/repertoires/_scraping_result.html.erb
+++ b/app/views/repertoires/_scraping_result.html.erb
@@ -1,0 +1,1 @@
+<h3>< %= @ingredient_names %></h3>

--- a/app/views/repertoires/edit.html.erb
+++ b/app/views/repertoires/edit.html.erb
@@ -1,9 +1,10 @@
-<% content_for(:name, @repertoire.name) %>
-<div class="container">
-  <div class="row">
-    <div class="col-lg-8 offset-lg-2">
-      <h1><%= @repertoire.name %></h1>
-      <%= render 'form', { repertoire: @repertoire } %>
+<div class="flex items-center justify-center ">
+  <% content_for(:name, @repertoire.name) %>
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-8 offset-lg-2">
+        <%= render 'form', { repertoire: @repertoire } %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/scrapers/index.html.erb
+++ b/app/views/scrapers/index.html.erb
@@ -1,2 +1,19 @@
-<h1>Scrapers#index</h1>
-<p>Find me in app/views/scrapers/index.html.erb</p>
+<div class="top-wrapper">
+  <div class="container">
+    <h1>スクレイピングフォーム</h1>
+
+    <%= form_tag('/scrapers/scrape', method: 'post') do %>
+      <div class="mb-3">
+        <label for="url" class="form-label">利用するレシピのURL:</label>
+        <%= text_field_tag(:url, nil, class: 'form-control', id: 'exampleFormControlInput1', placeholder: 'URLを貼り付けてください') %>
+      </div>
+      <div class="mb-3">
+        <label for="name" class="form-label">料理名:</label>
+        <%= text_field_tag(:name, nil, class: 'form-control', id: 'exampleFormControlInput2', placeholder: '料理名') %>
+      </div>
+      <div class="mb-3">
+        <button type="submit" class="btn btn-primary mb-3">スクレイピング開始</button>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/scrapers/index.html.erb
+++ b/app/views/scrapers/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Scrapers#index</h1>
+<p>Find me in app/views/scrapers/index.html.erb</p>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if object.errors.any? %>
-  <div id="error_messages" class="alert alert-danger">
+  <div id="error_messages" class="mt-5 p-5 leading-normal text-red-700 border border-red-500 rounded-lg" role="alert">
     <ul class="mb-0">
       <% object.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,9 +1,7 @@
 <% if object.errors.any? %>
-  <div id="error_messages" class="mt-5 p-5 leading-normal text-red-700 border border-red-500 rounded-lg" role="alert">
-    <ul class="mb-0">
-      <% object.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
+  <div class="text-red-500 text-sm">
+    <% object.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,6 +1,7 @@
-<% flash.each do |type, message| %>
-  <div class="alert alert-<%= type %>">
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-    <span><%= message %></span>
-  </div>
-<% end %>
+<div class="px-20">
+  <% flash.each do |type, message| %>
+    <div class="<%= flash_class(type) %> p-5 leading-normal rounded-lg" role="alert">
+      <span><%= message %></span>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -25,14 +25,8 @@
           </div>
         </label>
         <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
-          <li>
-            <%= link_to repertoires_path, class: 'justify-between' do %>
-              <%= t 'defaults.repertory' %>
-              <%= link_to new_repertoire_path do %>
-                <span class="badge">New</span>
-              <% end %>
-            <% end %>
-          </li>
+          <li><%= link_to Repertoire.model_name.human, repertoires_path %></li>
+          <li><%= link_to (t 'defaults.repertoire.new'), new_repertoire_path %></li>
           <li><%= link_to (t 'defaults.profile'), "#" %></li>
           <li><%= link_to (t 'defaults.logout'), destroy_user_session_path, data: { turbo_method: :delete } %></li>
         </ul>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -2,15 +2,23 @@ ja:
   activerecord:
     models:
       user: "ユーザー"
-      repertory: "レパートリー"
+      repertoire: "レパートリー"
       ingredient: "食材"
     attributes:
       user:
         email: "メールアドレス"
         password: "パスワード"
-        password_confirmation: "パスワード確認"
-        last_name: "姓"
-        first_name: "名"
-      repertory:
-        recipe_url: "レシピのURL"
+      repertoire:
         name: "料理名"
+        recipe_url: "レシピURL"
+        user_id: "ユーザーID"
+      ingredient:
+        name: "食材"
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              blank: "メールアドレスを入力してください"
+            password:
+              blank: "パスワードを入力してください"

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       user: "ユーザー"
       repertory: "レパートリー"
+      ingredient: "食材"
     attributes:
       user:
         email: "メールアドレス"
@@ -10,3 +11,6 @@ ja:
         password_confirmation: "パスワード確認"
         last_name: "姓"
         first_name: "名"
+      repertory:
+        recipe_url: "レシピのURL"
+        name: "料理名"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,25 +1,7 @@
 ja:
-  hello: "こんにちは"
-  activerecord:
-    models:
-      user: "ユーザー"
-      repertoire: "レパートリー"
-      ingredient: "食材"
-    attributes:
-      user:
-        email: "メールアドレス"
-        password: "パスワード"
-      repertoire:
-        name: "料理名"
-        recipe_url: "レシピURL"
-        user_id: "ユーザーID"
-      ingredient:
-        name: "食材"
-    errors:
-      models:
-        user:
-          attributes:
-            email:
-              blank: "メールアドレスを入力してください"
-            password:
-              blank: "パスワードを入力してください"
+  defaults:
+    repertoire: レパートリー
+    repertoire:
+      new: レパートリー登録
+      edit: レパートリー編集
+      destroy: レパートリー削除

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,25 @@
+ja:
+  hello: "こんにちは"
+  activerecord:
+    models:
+      user: "ユーザー"
+      repertoire: "レパートリー"
+      ingredient: "食材"
+    attributes:
+      user:
+        email: "メールアドレス"
+        password: "パスワード"
+      repertoire:
+        name: "料理名"
+        recipe_url: "レシピURL"
+        user_id: "ユーザーID"
+      ingredient:
+        name: "食材"
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              blank: "メールアドレスを入力してください"
+            password:
+              blank: "パスワードを入力してください"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,11 @@ Rails.application.routes.draw do
   sessions: "sessions"
 }
 
-  resources :repertoires
-  post 'repertoires/scrape', to: 'repertoires#scrape'
+  resources :repertoires do
+    collection do
+      post :scrape
+    end
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'scrapers/index'
   root "tops#index"
 
   devise_for :users, controllers: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,11 +7,10 @@ Rails.application.routes.draw do
 }
 
   resources :repertoires
+  post 'repertoires/scrape', to: 'repertoires#scrape'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
   post '/callback', to: 'linebot#callback'
 
-  get '/scrapers/index', to: 'scrapers#index'
-  post '/scrapers/scrape', to: 'scrapers#scrape'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'scrapers/index'
   root "tops#index"
 
   devise_for :users, controllers: {
@@ -13,4 +12,6 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   post '/callback', to: 'linebot#callback'
 
+  get '/scrapers/index', to: 'scrapers#index'
+  post '/scrapers/scrape', to: 'scrapers#scrape'
 end

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:3.2.2
+ENV LANG C.UTF-8
+ENV TZ Asia/Tokyo
+RUN apt-get update -qq \
+&& apt-get install -y ca-certificates curl gnupg \
+&& mkdir -p /etc/apt/keyrings \
+&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+&& NODE_MAJOR=20 \
+&& echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+&& wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+&& echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+&& apt-get update -qq \
+&& apt-get install -y build-essential libpq-dev libssl-dev nodejs yarn
+RUN mkdir /app
+WORKDIR /app
+RUN gem install bundler
+COPY .. /app

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,36 @@
+services:
+  db:
+    image: postgres:14
+    restart: always
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    environment:
+      TZ: "Asia/Tokyo"
+      POSTGRES_PASSWORD: password
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  web:
+    build: .
+    command: bash -c "bundle && yarn && bundle exec rails db:prepare && yarn build:css && rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    tty: true
+    stdin_open: true
+    volumes:
+      - ../:/app
+      - bundle_data:/usr/local/bundle:cached
+      - node_modules:/app/node_modules
+    environment:
+      TZ: Asia/Tokyo
+    ports:
+      - "3000:3000"
+    depends_on:
+      db:
+        condition: service_healthy
+volumes:
+  postgres_data:
+  bundle_data:
+  node_modules:

--- a/docker/database.yml.docker
+++ b/docker/database.yml.docker
@@ -1,0 +1,21 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: db
+  username: postgres
+  password: password
+
+
+development:
+  <<: *default
+  database: menu_memoire-db-1
+
+test:
+  <<: *default
+  database: menu_memoire-db-1
+
+
+production:
+  <<: *default
+  password: <%= ENV["MYAPP_DATABASE_PASSWORD"] %>

--- a/test/controllers/scrapers_controller_test.rb
+++ b/test/controllers/scrapers_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class ScrapersControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get scrapers_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
### プルリクエストの概要
本プルリクエストでは、レシピサイトCookpadのレシピURLから食材をスクレイピングし、フォームにカンマ区切りで取得する機能を実装しました。この機能により、ユーザーは手動で食材を入力する代わりに、レシピURLを使用して自動的に食材リストを生成できます

### 主な機能
- CookpadレシピのURLを入力して食材をスクレイピング
- スクレイピングされた食材はカンマ区切りでフォームに表示
- 重複する食材がある場合は、一意の食材として処理
- バリデーションエラーやその他のエラーが発生した場合、入力されたURLと食材が保持される

### 確認方法
- レパートリー登録フォームにCookpadのレシピURLを入力
- 「食材取得」ボタンをクリックすると、関連する食材がフォームに表示される
- レパートリー登録に失敗した場合、入力されたURLと食材がフォームに保持される
- レパートリー詳細で確認した際、重複する食材が一意に表示される

### 今後の改善点
- 食材フォームにすでに入力がある場合、食材取得ボタンを押すと消えてしまう
- レシピサイトの管理を行いたいため使用できるサイトを増やす
- 特に登録に際するUIがわかりにくい

その他なにか改善点や不明点ございましたらご指摘お願い致します

### 環境構築方法
`$ git clone -b ingredient_scraping git@github.com:anna-cat51/menu_memoire.git`
`$ cd menu_memoire`
`$ docker compose up`